### PR TITLE
Use `latest` version

### DIFF
--- a/src/plaid/core/auth/auth.api.ts
+++ b/src/plaid/core/auth/auth.api.ts
@@ -5,7 +5,7 @@ import {HttpClient} from '@angular/common/http';
 
 @Injectable({ providedIn: 'root' })
 export class AuthApi {
-  private myselfUrl = '/rest/api/2/myself';
+  private myselfUrl = '/rest/api/latest/myself';
 
   constructor(private http: HttpClient) { }
 

--- a/src/plaid/core/issue/issue.api.ts
+++ b/src/plaid/core/issue/issue.api.ts
@@ -7,8 +7,8 @@ import { SearchResults } from '../../model/search-results';
 
 @Injectable({ providedIn: 'root' })
 export class IssueApi {
-  private readonly getIssueUrl = '/rest/api/2/issue/{issueIdOrKey}';
-  private readonly searchUrl = '/rest/api/3/search/jql';
+  private readonly getIssueUrl = '/rest/api/latest/issue/{issueIdOrKey}';
+  private readonly searchUrl = '/rest/api/latest/search/jql';
 
   constructor(private http: HttpClient) { }
 

--- a/src/plaid/core/worklog/worklog.api.ts
+++ b/src/plaid/core/worklog/worklog.api.ts
@@ -10,11 +10,11 @@ import { DateRange } from '../../model/date-range';
 
 @Injectable({ providedIn: 'root' })
 export class WorklogApi {
-  private readonly searchUrl = '/rest/api/3/search/jql';
-  private readonly getWorklogsUrl = '/rest/api/2/issue/{issueIdOrKey}/worklog';
-  private readonly addWorklogUrl = '/rest/api/2/issue/{issueIdOrKey}/worklog';
-  private readonly updateWorklogUrl = '/rest/api/2/issue/{issueIdOrKey}/worklog/{id}';
-  private readonly deleteWorklogUrl = '/rest/api/2/issue/{issueIdOrKey}/worklog/{id}';
+  private readonly searchUrl = '/rest/api/latest/search/jql';
+  private readonly getWorklogsUrl = '/rest/api/latest/issue/{issueIdOrKey}/worklog';
+  private readonly addWorklogUrl = '/rest/api/latest/issue/{issueIdOrKey}/worklog';
+  private readonly updateWorklogUrl = '/rest/api/latest/issue/{issueIdOrKey}/worklog/{id}';
+  private readonly deleteWorklogUrl = '/rest/api/latest/issue/{issueIdOrKey}/worklog/{id}';
 
   constructor(private http: HttpClient) { }
 


### PR DESCRIPTION
It's possible to use the symbolic name `latest` instead of a fixed version. This will work when jira updates the version but does not change the urls/api.